### PR TITLE
DM-50568: Parallelize EstimateZernikes

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-14.5.0:
+
+-------------
+ 14.5.0
+-------------
+
+* Add CalcZernikesTask multiprocessing.
+
 .. _lsst.ts.wep-14.4.1:
 
 -------------

--- a/python/lsst/ts/wep/task/calcZernikesUnpairedTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesUnpairedTask.py
@@ -111,11 +111,11 @@ class CalcZernikesUnpairedTask(CalcZernikesTask):
         # Assign stamps to either intra or extra
         if selectedDonuts[0].wep_im.defocalType == DefocalType.Extra:
             extraStamps = selectedDonuts
-            intraStamps = []
+            intraStamps = DonutStamps([])
             if len(donutQualityTable) > 0:
                 donutQualityTable["DEFOCAL_TYPE"] = "extra"
         else:
-            extraStamps = []
+            extraStamps = DonutStamps([])
             intraStamps = selectedDonuts
             if len(donutQualityTable) > 0:
                 donutQualityTable["DEFOCAL_TYPE"] = "intra"

--- a/tests/task/test_calcZernikesDanishTaskCwfs.py
+++ b/tests/task/test_calcZernikesDanishTaskCwfs.py
@@ -255,9 +255,14 @@ class TestCalcZernikesDanishTaskCwfs(lsst.utils.tests.TestCase):
         )
 
         # First estimate without pairs
-        zkAllExtra = self.task.estimateZernikes.run(donutStampsExtra, []).zernikes
+        emptyStamps = DonutStamps([])
+        zkAllExtra = self.task.estimateZernikes.run(
+            donutStampsExtra, emptyStamps
+        ).zernikes
         zkAvgExtra = self.task.combineZernikes.run(zkAllExtra).combinedZernikes
-        zkAllIntra = self.task.estimateZernikes.run([], donutStampsIntra).zernikes
+        zkAllIntra = self.task.estimateZernikes.run(
+            emptyStamps, donutStampsIntra
+        ).zernikes
         zkAvgIntra = self.task.combineZernikes.run(zkAllIntra).combinedZernikes
 
         # Now estimate with pairs

--- a/tests/task/test_calcZernikesUnpairedTask.py
+++ b/tests/task/test_calcZernikesUnpairedTask.py
@@ -150,8 +150,6 @@ class TestCalcZernikeUnpaired(lsst.utils.tests.TestCase):
                 task = CalcZernikesUnpairedTask(config=config)
                 structNormal = task.run(stamps)
 
-                # import pytest; pytest.set_trace()
-
                 # check that 4 elements are created
                 self.assertEqual(len(structNormal), 4)
 


### PR DESCRIPTION
Adds an option to EstimateZernikesBase to parallelize over donuts.

On the summit, using 4 cores makes CalcZernikesTask run about 2x faster.