### PR TITLE
Tickets/DM-51277: fix behavior for no donut stamp selection

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -5,6 +5,14 @@
 ##################
 Version History
 ##################
+.. _lsst.ts.wep-14.11.0:
+
+-------------
+ 14.11.0
+-------------
+
+* Fix behavior of calcZernikesTask when doDonutStampSelector is False.
+* Add doSelection config to donutStampSelectorTaskConfig.
 
 .. _lsst.ts.wep-14.10.1:
 


### PR DESCRIPTION
Fixed `calcZernikesTask` so that it uses all donuts when `doDonutStampSelector` is False (i.e. `DonutStampSelector` is not run, all donuts used, `donutQualityTable` is empty).  Added to `DonutStampSelector` a `doSelection` config, so that it can be run (creating the `donutQualityTable`), but selecting all donuts. 