### PR TITLE
Tickets/DM-51516: make radius task more robust

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -5,6 +5,14 @@
 ##################
 Version History
 ##################
+.. _lsst.ts.wep-14.13.0:
+
+-------------
+ 14.13.0
+-------------
+
+* Fix fitDonutRadiusTask to use median of cuts at different angles.
+
 .. _lsst.ts.wep-14.12.0:
 
 -------------

--- a/python/lsst/ts/wep/task/fitDonutRadiusTask.py
+++ b/python/lsst/ts/wep/task/fitDonutRadiusTask.py
@@ -3,9 +3,11 @@ import lsst.pipe.base as pipeBase
 import numpy as np
 from astropy.table import QTable
 from lsst.ts.wep.task.donutStamps import DonutStamps
+from lsst.ts.wep.utils import binArray
 from lsst.utils.timer import timeMethod
 from scipy.ndimage import gaussian_filter
 from scipy.signal import find_peaks
+from skimage.measure import profile_line
 
 __all__ = [
     "FitDonutRadiusTaskConfig",
@@ -47,6 +49,14 @@ class FitDonutRadiusTaskConfig(pexConfig.Config):
         0 and 1).",
         default=0.8,
     )
+    nAngles = pexConfig.Field[int](
+        doc="Number of angles for cross-sections.",
+        default=10,
+    )
+    binning = pexConfig.Field[int](
+        doc="Binning applied to each donut postage stamp.",
+        default=1,
+    )
 
 class FitDonutRadiusTask(pipeBase.Task):
     ConfigClass = FitDonutRadiusTaskConfig
@@ -54,6 +64,7 @@ class FitDonutRadiusTask(pipeBase.Task):
     """
     Run donut radius fitting.
     """
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -63,6 +74,8 @@ class FitDonutRadiusTask(pipeBase.Task):
         self.minPeakHeight = self.config.minPeakHeight
         self.leftDefault = self.config.leftDefault
         self.rightDefault = self.config.rightDefault
+        self.nAngles = self.config.nAngles
+        self.binning = self.config.binning
 
     def empty(self) -> pipeBase.Struct:
         """Return empty table if no donut stamps are available.
@@ -111,7 +124,9 @@ class FitDonutRadiusTask(pipeBase.Task):
         failedFlagArray = []
 
         for stamp in stampSet:
-            xLeft, xRight, donutRadius, flag = self.fit_radius(stamp.stamp_im.image.array)
+            xLeft, xRight, donutRadius, flag = self.fit_radius(
+                stamp.stamp_im.image.array
+            )
             radiiArray.append(donutRadius)
             leftEdgeArray.append(xLeft)
             rightEdgeArray.append(xRight)
@@ -132,7 +147,7 @@ class FitDonutRadiusTask(pipeBase.Task):
 
         return pipeBase.Struct(donutRadiiTable=donutRadiiTable)
 
-    def fit_radius(self, image):
+    def fit_radius(self, image: np.array):
         """
         Find peaks and widths of smoothed donut cross-section.
         The donut cross-section is normalized, and
@@ -160,8 +175,9 @@ class FitDonutRadiusTask(pipeBase.Task):
             a warning is logged).
 
         """
-        halfWidth = int(len(image) / 2)
-        y_cross = image[halfWidth, :]
+        if self.binning > 1:
+            image = binArray(image, self.binning)
+        y_cross = self.get_median_profile(image, nangles=self.nAngles)
         y_cross_norm = np.array(y_cross) / max(y_cross)
         fail_flag = 0
         # convolve with Gaussian filter to smooth out the cross-section
@@ -211,4 +227,47 @@ class FitDonutRadiusTask(pipeBase.Task):
         # donut radius is half of the distance
         # between two edges
         radius = (right_edge - left_edge) / 2.0
+
+        # if the image was binned, need to return to original scale
+        if self.binning > 1:
+            radius = radius * self.binning
         return left_edge, right_edge, radius, fail_flag
+
+    def get_line_profile(self, image: np.ndarray, angle_deg: float = 0):
+
+        # Center of image
+        center = np.array(image.shape) // 2
+
+        # Length of the cross-section line
+        length = len(image)  # number of pixels to sample
+
+        # Angle in degrees
+        angle_rad = np.deg2rad(angle_deg)
+
+        # Compute endpoints
+        dx = np.cos(angle_rad) * length / 2
+        dy = np.sin(angle_rad) * length / 2
+
+        start = (center[0] - dy, center[1] - dx)
+        end = (center[0] + dy, center[1] + dx)
+
+        # Extract profile
+        profile = profile_line(
+            image,
+            start,
+            end,
+            mode="constant",
+        )
+
+        if len(profile) > length:
+            profile = profile[:length]
+        return profile
+
+    def get_median_profile(self, image: np.ndarray, nangles: int = 20):
+        angles = np.linspace(0, 180, nangles)
+        profiles = []
+        for angle in angles:
+            profile = self.get_line_profile(image, angle)
+            profiles.append(profile)
+        profiles = np.array(profiles)
+        return np.median(profiles, axis=0)

--- a/python/lsst/ts/wep/task/fitDonutRadiusTask.py
+++ b/python/lsst/ts/wep/task/fitDonutRadiusTask.py
@@ -58,6 +58,7 @@ class FitDonutRadiusTaskConfig(pexConfig.Config):
         default=1,
     )
 
+
 class FitDonutRadiusTask(pipeBase.Task):
     ConfigClass = FitDonutRadiusTaskConfig
     _DefaultName = "FitDonutRadius"
@@ -175,6 +176,7 @@ class FitDonutRadiusTask(pipeBase.Task):
             a warning is logged).
 
         """
+        # apply image binning if needed
         if self.binning > 1:
             image = binArray(image, self.binning)
         y_cross = self.get_median_profile(image, nangles=self.nAngles)
@@ -231,6 +233,8 @@ class FitDonutRadiusTask(pipeBase.Task):
         # if the image was binned, need to return to original scale
         if self.binning > 1:
             radius = radius * self.binning
+            left_edge = left_edge * self.binning
+            right_edge = right_edge * self.binning
         return left_edge, right_edge, radius, fail_flag
 
     def get_line_profile(self, image: np.ndarray, angle_deg: float = 0):

--- a/tests/task/test_cutOutDonutsBase.py
+++ b/tests/task/test_cutOutDonutsBase.py
@@ -70,12 +70,14 @@ class TestCutOutDonutsBase(lsst.utils.tests.TestCase):
 
             collections = "refcats/gen2,LSSTCam/calib,LSSTCam/raw/all"
             instrument = "lsst.obs.lsst.LsstCam"
-            pipelineYaml = os.path.join(
-                testPipelineConfigDir, "testBasePipeline.yaml"
-            )
+            pipelineYaml = os.path.join(testPipelineConfigDir, "testBasePipeline.yaml")
 
             pipeCmd = writePipetaskCmd(
-                cls.repoDir, cls.runName, instrument, collections, pipelineYaml=pipelineYaml
+                cls.repoDir,
+                cls.runName,
+                instrument,
+                collections,
+                pipelineYaml=pipelineYaml,
             )
             # Make sure we are using the right exposure+detector combinations
             pipeCmd += ' -d "exposure IN (4021123106001, 4021123106002) AND '
@@ -289,13 +291,16 @@ class TestCutOutDonutsBase(lsst.utils.tests.TestCase):
             donutStamps = self.task.cutOutStamps(
                 exp, catalog, DefocalType.Extra, self.cameraName
             )
-        # Test that there are warnings for two objects
-        # since first object should pass
-        self.assertEqual(len(cm.output), 2)
+
         # All donuts except the first one should have unchanged values
+        # Pick only the recentering warnings
         recenteringWarnings = [
             warn for warn in cm.output if "Donut Recentering " in warn
         ]
+        # Test that there are recentering warnings for two objects
+        # since first object should pass
+        self.assertEqual(len(recenteringWarnings), 2)
+
         for stamp, catRow, logMsg, xShift, yShift in zip(
             donutStamps[1:],
             catalog[1:],
@@ -483,8 +488,9 @@ class TestCutOutDonutsBase(lsst.utils.tests.TestCase):
         # test the calculation of SN
         sn_values = [2149.093503846915, 2160.668317852145, 2041.9917562475855]
         sn_calculated = donutStamps.metadata.getArray("SN")
-        self.assertFloatsAlmostEqual(np.sort(np.array(sn_values)),
-                                     np.sort(np.array(sn_calculated)), rtol=1e-3)
+        self.assertFloatsAlmostEqual(
+            np.sort(np.array(sn_values)), np.sort(np.array(sn_calculated)), rtol=1e-3
+        )
 
     def testFilterBadRecentering(self):
         maxRecenter = 25
@@ -587,12 +593,10 @@ class TestCutOutDonutsBase(lsst.utils.tests.TestCase):
             "BORESIGHT_RA_RAD",
             "BORESIGHT_DEC_RAD",
         ]
-        self.assertCountEqual(key_list,list(donutStamps.metadata.keys()))
+        self.assertCountEqual(key_list, list(donutStamps.metadata.keys()))
 
         # Test a few values
         self.assertEqual(
             donutStamps.metadata.get("BANDPASS"), exposure.filter.bandLabel
         )
-        self.assertEqual(
-            donutStamps.metadata.get("VISIT"), self.dataIdExtra["visit"]
-        )
+        self.assertEqual(donutStamps.metadata.get("VISIT"), self.dataIdExtra["visit"])

--- a/tests/task/test_fitDonutRadiusTask.py
+++ b/tests/task/test_fitDonutRadiusTask.py
@@ -66,17 +66,23 @@ class TestFitDonutRadiusTaskScienceSensor(lsst.utils.tests.TestCase):
         self.assertEqual(self.OrigTask.filterSigma, 3)
         self.assertEqual(self.OrigTask.minPeakWidth, 5)
         self.assertEqual(self.OrigTask.minPeakHeight, 0.3)
+        self.assertEqual(self.OrigTask.nAngles, 10)
+        self.assertEqual(self.OrigTask.binning, 1)
 
         # Test changing configs
         self.config.widthMultiplier = 2.00
         self.config.filterSigma = 4
         self.config.minPeakWidth = 7
         self.config.minPeakHeight = 0.8
+        self.config.nAngles = 20
+        self.config.binning = 2
         self.ModifiedTask = FitDonutRadiusTask(config=self.config, name="Mod Task")
         self.assertEqual(self.ModifiedTask.widthMultiplier, 2.00)
         self.assertEqual(self.ModifiedTask.filterSigma, 4)
         self.assertEqual(self.ModifiedTask.minPeakWidth, 7)
         self.assertEqual(self.ModifiedTask.minPeakHeight, 0.8)
+        self.assertEqual(self.ModifiedTask.nAngles, 20)
+        self.assertEqual(self.ModifiedTask.binning, 2)
 
     def testTaskRunScienceSensor(self):
         donutStampsExtra = self.butler.get(


### PR DESCRIPTION
Calculation of donut radius with median of cuts across different angles, on a postage stamp that may be binned. Adding appropriate config options to facilitate that: `nAngles` and `binning`