### PR TITLE
Fix missing logic in generateDonutFromRefitWcsTask that caused failur…

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -5,11 +5,21 @@
 ##################
 Version History
 ##################
+
+.. _lsst.ts.wep-14.16.1:
+
+-------------
+ 14.16.1
+-------------
+
+* Fix missing logic in generateDonutFromRefitWcsTask that caused failures when scatter in WCS fit was too large.
+
 .. _lsst.ts.wep-14.16.0:
 
 -------------
  14.16.0
 -------------
+
 * Add DonutSizeCorrelator to measure donut diameters at the exposure level.
 * Updated handling of radius information to donut stamps metadata, and donut quality table.
 

--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -13,6 +13,7 @@ Version History
 -------------
 
 * Fix missing logic in generateDonutFromRefitWcsTask that caused failures when scatter in WCS fit was too large.
+* Return original post_isr_image with new WCS if WCS fit successful.
 
 .. _lsst.ts.wep-14.16.0:
 

--- a/python/lsst/ts/wep/task/generateDonutFromRefitWcsTask.py
+++ b/python/lsst/ts/wep/task/generateDonutFromRefitWcsTask.py
@@ -338,6 +338,15 @@ class GenerateDonutFromRefitWcsTask(GenerateDonutCatalogWcsTask):
             if scatter < self.config.maxFitScatter:
                 successfulFit = True
                 self.metadata["wcsFitSuccess"] = True
+            else:
+                # this is set to None when the fit fails, so restore it
+                exposure.setWcs(originalWcs)
+                donutCatalog = fitDonutCatalog
+                self.log.warning(
+                    "Returning original exposure and WCS and "
+                    "direct detect catalog as output."
+                )
+
         except (RuntimeError, TaskError, IndexError, ValueError, AttributeError) as e:
             # IndexError raised for low source counts:
             # index 0 is out of bounds for axis 0 with size 0

--- a/python/lsst/ts/wep/task/generateDonutFromRefitWcsTask.py
+++ b/python/lsst/ts/wep/task/generateDonutFromRefitWcsTask.py
@@ -339,7 +339,7 @@ class GenerateDonutFromRefitWcsTask(GenerateDonutCatalogWcsTask):
                 successfulFit = True
                 self.metadata["wcsFitSuccess"] = True
             else:
-                # this is set to None when the fit fails, so restore it
+                # WCS has been updated already but we are rolling back, so restore it
                 exposure.setWcs(originalWcs)
                 donutCatalog = fitDonutCatalog
                 self.log.warning(


### PR DESCRIPTION
…es when scatter in WCS fit was too large.