### PR TITLE
Add additional danish model parameters to zernike metadata.

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -5,6 +5,14 @@
 ##################
 Version History
 ##################
+.. _lsst.ts.wep-15.0.2:
+
+-------------
+15.0.2
+-------------
+
+* Add model parameters to metadata in Danish estimator outputs.
+
 .. _lsst.ts.wep-15.0.1:
 
 -------------

--- a/python/lsst/ts/wep/estimation/danish.py
+++ b/python/lsst/ts/wep/estimation/danish.py
@@ -338,6 +338,10 @@ class DanishAlgorithm(WfAlgorithm):
 
         # Save final fwhm value in metadata
         zkMeta = {"fwhm": fwhm}
+        # Add model information
+        zkMeta["model_dx"] = dx
+        zkMeta["model_dy"] = dy
+        zkMeta["model_sky_level"] = backgroundStd**2
 
         return zkSum, hist, zkMeta
 
@@ -509,6 +513,10 @@ class DanishAlgorithm(WfAlgorithm):
 
         # Save final fwhm value in metadata
         zkMeta = {"fwhm": fwhm}
+        # Add model information
+        zkMeta["model_dx"] = dxs
+        zkMeta["model_dy"] = dys
+        zkMeta["model_sky_level"] = skyLevels
 
         return zkSum, hist, zkMeta
 

--- a/tests/estimation/test_danish.py
+++ b/tests/estimation/test_danish.py
@@ -140,5 +140,16 @@ class TestDanishAlgorithm(unittest.TestCase):
 
         # Check metadata
         for metaDict in pairMeta, intraMeta, extraMeta:
-            self.assertEqual(["fwhm"], list(metaDict.keys()))
+            self.assertEqual(["fwhm", "model_dx", "model_dy", "model_sky_level"], list(metaDict.keys()))
             self.assertAlmostEqual(metaDict["fwhm"], 1.034, delta=0.01)
+        np.testing.assert_allclose(
+            pairMeta["model_dx"], [intraMeta["model_dx"], extraMeta["model_dx"]], atol=0.01
+        )
+        np.testing.assert_allclose(
+            pairMeta["model_dy"], [intraMeta["model_dy"], extraMeta["model_dy"]], atol=0.01
+        )
+        np.testing.assert_allclose(
+            pairMeta["model_sky_level"],
+            [intraMeta["model_sky_level"], extraMeta["model_sky_level"]],
+            atol=0.01,
+        )

--- a/tests/task/test_calcZernikesDanishTaskCwfs.py
+++ b/tests/task/test_calcZernikesDanishTaskCwfs.py
@@ -291,6 +291,9 @@ class TestCalcZernikesDanishTaskCwfs(lsst.utils.tests.TestCase):
         self.assertIn("cam_name", zkCalcPairs.meta)
         self.assertIn("estimatorInfo", zkCalcPairs.meta)
         self.assertIn("fwhm", zkCalcPairs.meta["estimatorInfo"])
+        self.assertIn("model_dx", zkCalcPairs.meta["estimatorInfo"])
+        self.assertIn("model_dy", zkCalcPairs.meta["estimatorInfo"])
+        self.assertIn("model_sky_level", zkCalcPairs.meta["estimatorInfo"])
         self.assertEqual(2, len(zkCalcPairs.meta["estimatorInfo"]["fwhm"]))
         for stamps, k in zip([self.donutStampsIntra, self.donutStampsExtra], ["intra", "extra"]):
             dict_ = zkCalcPairs.meta[k]


### PR DESCRIPTION
Paired with changes in https://github.com/lsst-ts/donut_viz/pull/65 to enable easy interactive visualization of the model donuts calculated by danish.