### PR TITLE
Added height map to instrument

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -115,3 +115,5 @@ tests/testData/gen3TestRepo/LSSTCam/raw/all/raw/20211231/MC_H_20211231_006002/ra
 tests/testData/gen3TestRepo/LSSTCam/raw/all/raw/20211231/MC_H_20211231_006008/raw_LSSTCam_g_MC_H_20211231_006008_R22_S11_LSSTCam_raw_all.fits.gz filter=lfs diff=lfs merge=lfs -text
 tests/testData/gen3TestRepo/LSSTCam/raw/all/raw/20211231/MC_H_20211231_006009/raw_LSSTCam_g_MC_H_20211231_006009_R22_S11_LSSTCam_raw_all.fits.gz filter=lfs diff=lfs merge=lfs -text
 *.pt filter=lfs diff=lfs merge=lfs -text
+policy/heightMaps/LSST_FP_cold_b_measurement_4col_bysurface.fits filter=lfs diff=lfs merge=lfs -text
+policy/heightMaps/LsstCam_focal_plane_heights_interpolated.fits filter=lfs diff=lfs merge=lfs -text

--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -5,6 +5,15 @@
 ##################
 Version History
 ##################
+
+.. _lsst.ts.wep-15.1.0:
+
+-------------
+15.1.0
+-------------
+
+* Added focal plane height map functionality to the Instrument class
+
 .. _lsst.ts.wep-15.0.2:
 
 -------------

--- a/policy/heightMaps/LSST_FP_cold_b_measurement_4col_bysurface.fits
+++ b/policy/heightMaps/LSST_FP_cold_b_measurement_4col_bysurface.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d4a83c037543b65205a27cefae78e17a4e5354953cfe9904d548a476fe746d3
+size 14417920

--- a/policy/heightMaps/LsstCam_focal_plane_heights_interpolated.fits
+++ b/policy/heightMaps/LsstCam_focal_plane_heights_interpolated.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bb0a7a8e67b390164231c179aae736f040d6cc078a1f052144e754965580287
+size 24007680

--- a/policy/instruments/LsstCam.yaml
+++ b/policy/instruments/LsstCam.yaml
@@ -20,6 +20,7 @@ wavelength:
   z: 866.8e-9
   y: 973.9e-9
 batoidModelName: LSST_{band} # name used to load the Batoid model
+heightMap: policy:heightMaps/LsstCam_focal_plane_heights_interpolated.fits
 
 maskParams: # center and radius are in meters, theta in degrees
   M1:

--- a/python/lsst/ts/wep/instrument.py
+++ b/python/lsst/ts/wep/instrument.py
@@ -108,8 +108,10 @@ class Instrument:
     heightMap : str or astropy.table.Table or None, optional
         Astropy table that holds the focal plane height map, or the path to
         where it is saved. The table columns should have names "x", "y", and
-        "z" with units of length. If None, no height map is used.
-        (the default is None)
+        "z" with astropy units of length. The x and y coordinates must be
+        aligned with the x,y coordinates of the Detector in the Batoid model.
+        The +z direction is in the extrafocal direction. If None, no height
+        map is used. (the default is None)
     maskParams : dict, optional
         Dictionary of mask parameters. Each key in this dictionary corresponds
         to a different mask element. The corresponding values are dictionaries
@@ -728,7 +730,10 @@ class Instrument:
         value : str or None
             Astropy table that holds the focal plane height map, or the path to
             where it is saved. The table columns should have names "x", "y",
-            and "z" with units of length. If None, no height map is used.
+            and "z" with astropy units of length. The x and y coordinates must
+            be aligned with the x,y coordinates of the Detector in the Batoid
+            model. The +z direction is in the extrafocal direction. If None,
+            no height map is used.
         """
         if value is None:
             self._heightMap = None
@@ -749,9 +754,7 @@ class Instrument:
         z = value["z"].to("m").value.reshape(x.size, y.size)  # type: ignore
 
         # Create the surface
-        # Notice the minus sign: +focal plane height moves the sensor
-        # in the direction from which the photons arrive.
-        self._heightMap = batoid.Bicubic(x, y, -z)
+        self._heightMap = batoid.Bicubic(x, y, z)
 
         # Clear relevant caches
         self._getIntrinsicZernikesTACached.cache_clear()

--- a/python/lsst/ts/wep/instrument.py
+++ b/python/lsst/ts/wep/instrument.py
@@ -744,9 +744,9 @@ class Instrument:
             value = Table.read(path)
 
         # Extract grid values from table
-        x = np.unique(value["x"].to("m").value)
-        y = np.unique(value["y"].to("m").value)
-        z = value["z"].to("m").value.reshape(x.size, y.size)
+        x = np.unique(value["x"].to("m").value)  # type: ignore
+        y = np.unique(value["y"].to("m").value)  # type: ignore
+        z = value["z"].to("m").value.reshape(x.size, y.size)  # type: ignore
 
         # Create the surface
         # Notice the minus sign: +focal plane height moves the sensor

--- a/python/lsst/ts/wep/utils/__init__.py
+++ b/python/lsst/ts/wep/utils/__init__.py
@@ -1,3 +1,4 @@
+from .ccdHeightUtils import *
 from .enumUtils import *
 from .ioUtils import *
 from .maskUtils import *

--- a/python/lsst/ts/wep/utils/ccdHeightUtils.py
+++ b/python/lsst/ts/wep/utils/ccdHeightUtils.py
@@ -1,0 +1,203 @@
+# This file is part of ts_wep.
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["LsstCamHeightMapBuilder"]
+
+from pathlib import Path
+
+import numpy as np
+from astropy.io import fits
+from astropy.table import Table
+from lsst.ts.wep.utils.ioUtils import resolveRelativeConfigPath
+from scipy.spatial import Delaunay
+from sklearn.neighbors import KNeighborsRegressor
+
+mapDir = "policy:heightMaps/"
+
+
+class LsstCamHeightMapBuilder:
+    """Class to convert height map provided by camera team to format for WEP.
+
+    Intended use:
+        from lsst.ts.wep.utils import LsstCamHeightMapBuilder
+        builder = LsstCamHeightMapBuilder()
+        builder.processFits()
+        builder.interpolateMap()
+    The resulting interpolated height map is committed to git and loaded
+    directly by WEP at runtime.
+    """
+
+    def __init__(
+        self,
+        rawFile: str = mapDir + "LSST_FP_cold_b_measurement_4col_bysurface.fits",
+        procFile: str = mapDir + "LsstCam_focal_plane_heights.fits",
+        interpFile: str = mapDir + "LsstCam_focal_plane_heights_interpolated.fits",
+        interpGrid: np.ndarray = np.linspace(-320, +320, 1000),
+    ) -> None:
+        """Initialize LsstCamHeightMapBuilder.
+
+        Parameters
+        ----------
+        rawFile : str
+            Path to raw input FITS file from camera team.
+        procFile : str
+            File in which to save the table of processed focal plane heights as
+            an Astropy table. Raw values are in this table, but the default
+            values have been adjusted to set the median of the science sensors
+            within 317mm of center to zero, and the CWFS offsets have been
+            removed.
+        interpFile : str
+            Path at which to save the interpolated focal plane height map.
+            This is also saved as an Astropy Table.
+        interpGrid : np.ndarray
+            1D array of x and y coordinates (in mm) for interpolation grid.
+        """
+        self.rawFile = Path(resolveRelativeConfigPath(rawFile))
+        self.procFile = Path(resolveRelativeConfigPath(procFile))
+        self.interpFile = Path(resolveRelativeConfigPath(interpFile))
+        self.interpGrid = interpGrid
+
+    def processFits(self, overWrite: bool = False) -> None:
+        """Process FITS file containing focal plane height measurements.
+
+        Reads focal plane height data from format provided by camera team
+        and saves it in an Astropy table.
+
+        Raw values are retained in this table, but the default values have been
+        adjusted to set the median of the science sensors within 317mm of
+        center to zero, and the CWFS offsets have been removed.
+
+        Parameters
+        ----------
+        overWrite : bool, optional
+            Whether to overwrite existing output file. (Default is False)
+        """
+        if self.procFile.exists() and not overWrite:
+            print(f"File {self.procFile} already exists. Skipping processFits.")
+            return
+
+        # Extract data from input fits file and save in a table
+        rows = []
+        for hdu in fits.open(self.rawFile):
+            if isinstance(hdu, fits.BinTableHDU):
+                extName = hdu.header["EXTNAME"]
+                if extName[0] == "R":
+                    table = Table(hdu.data)
+                    detector = extName[:3] + "_" + extName[3:]
+                    detector = detector.replace("WFS", "SW")
+                    for x, y, z_mod, z_meas in zip(
+                        table["X_CCS"],
+                        table["Y_CCS"],
+                        table["Z_CCS_MODEL"],
+                        table["Z_CCS_MEASURED"],
+                    ):
+                        rows.append([x, y, detector, z_mod, z_meas])
+        data = Table(
+            rows=rows,
+            names=["x_ccs", "y_ccs", "detector", "z_model_raw", "z_measured_raw"],
+            units=2 * ["mm"] + [None] + 2 * ["mm"],
+        )
+
+        # Set zero-point to median of science sensors within 317mm of center
+        mask = np.sqrt(data["x_ccs"] ** 2 + data["y_ccs"] ** 2) < 317
+        for i in range(len(data)):
+            if data[i]["detector"][-3] != "S" or data[i]["detector"][-2] == "W":
+                mask[i] = False
+        data["z_model"] = data["z_model_raw"] - np.median(data[mask]["z_model_raw"])
+        data["z_measured"] = data["z_measured_raw"] - np.median(
+            data[mask]["z_measured_raw"]
+        )
+
+        # Remove CWFS offsets
+        for i in range(len(data)):
+            if data[i]["detector"][-3:] == "SW1":
+                data[i]["z_model"] += 1.5
+                data[i]["z_measured"] += 1.5
+            elif data[i]["detector"][-3:] == "SW0":
+                data[i]["z_model"] -= 1.5
+                data[i]["z_measured"] -= 1.5
+
+        print(f"Saving {self.procFile}")
+        data.write(self.procFile, format="fits", overwrite=overWrite)
+
+    def interpolateMap(
+        self, overWrite: bool = False, mapType: str = "measured"
+    ) -> np.ndarray:
+        """Interpolate focal plane height map onto regular grid.
+
+        Parameters
+        ----------
+        overWrite : bool, optional
+            Whether to overwrite existing output file.
+            (Default is False)
+        mapType : str, optional
+            Type of map to interpolate ("measured" or "model").
+            (Default is "measured")
+        """
+        if self.interpFile.exists() and not overWrite:
+            print(f"File {self.interpFile} already exists. Skipping interpolateMap.")
+            return
+
+        # Load the processed data table
+        if not self.procFile.exists():
+            raise FileNotFoundError(
+                f"procFile {self.procFile} does not exist. "
+                "Please run processFits first."
+            )
+        table = Table.read(self.procFile)
+
+        # Create grids for interpolation
+        X, Y = np.meshgrid(self.interpGrid, self.interpGrid)
+        x = X.ravel()
+        y = Y.ravel()
+        z = np.zeros_like(x)
+
+        # Loop over every detector
+        for detector in np.unique(table["detector"]):
+            # Get data for this detector
+            data = table[table["detector"] == detector]
+
+            # Determine which points are inside this chip
+            mask = (x >= data["x_ccs"].min()) & (x <= data["x_ccs"].max())
+            mask &= (y >= data["y_ccs"].min()) & (y <= data["y_ccs"].max())
+
+            # Interpolate
+            knn = KNeighborsRegressor(n_neighbors=3, weights="distance")
+            points = np.column_stack((data["x_ccs"], data["y_ccs"]))
+            values = data[f"z_{mapType}"]
+            knn.fit(points, values)
+            z[mask] = knn.predict(np.column_stack((x, y))[mask])
+
+        # Set anything outside original convex hull to NaN
+        hull_points = np.column_stack([table["x_ccs"], table["y_ccs"]])
+        test_points = np.column_stack([x, y])
+        deln = Delaunay(hull_points)
+        inside = deln.find_simplex(test_points) >= 0
+        z[~inside] = np.nan
+
+        # Save in an Astropy table
+        data = Table(
+            rows=np.column_stack((x, y, z)),
+            names=["x", "y", "z"],
+            units=3 * ["mm"],
+        )
+        print(f"Saving {self.interpFile}")
+        data.write(self.interpFile, format="fits", overwrite=overWrite)

--- a/python/lsst/ts/wep/utils/ioUtils.py
+++ b/python/lsst/ts/wep/utils/ioUtils.py
@@ -66,21 +66,25 @@ def getConfigDir() -> str:
 
 
 def resolveRelativeConfigPath(path: str) -> str:
-    """Resolve a relative config path into an absolute path.
+    """Resolves policy paths.
 
     This does not check whether the absolute path actually points to a file.
+    If the path does not start with "policy:", it is returned unchanged.
 
     Parameters
     ----------
     path : str
-        Path relative to the policy directory. Can start with "policy:" or not.
+        Path to resolve. Can start with "policy:" or not.
 
     Returns
     -------
     str
-        Absolute path of config file in the policy directory
+        Resolved path.
     """
-    # Remove policy: prefix if present
+    if not path.startswith("policy:"):
+        return path
+
+    # Remove policy: prefix
     path = path.removeprefix("policy:")
 
     # Return the absolute policy path
@@ -115,10 +119,7 @@ def readConfigYaml(path: str, recurseImports: bool = True) -> dict:
         If recurseImports is True and 'imports' doesn't map to a string
         or 1D list of strings
     """
-    # Is the path relative to the policy directory?
-    if path.startswith("policy:"):
-        # Get absolute path including the policy directory path
-        path = resolveRelativeConfigPath(path)
+    path = resolveRelativeConfigPath(path)
 
     # Read the parameter file into a dictionary
     with open(path, "r") as file:

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -242,6 +242,10 @@ class TestInstrument(unittest.TestCase):
         for key in keys:
             self.assertEqual(getattr(lsst, key), getattr(comcam, key))
 
+    def testBadHeightMap(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            Instrument(heightMap="bad")
+
 
 if __name__ == "__main__":
     # Do the unit test

--- a/tests/utils/test_modelUtils.py
+++ b/tests/utils/test_modelUtils.py
@@ -139,8 +139,8 @@ class TestModelUtils(unittest.TestCase):
             zkCoeff=[0],
         )
 
-        # Check that intrafocal isn't too much bigger than extrafocal
-        self.assertTrue(np.sum(intra.image > 0) - np.sum(extra.image > 0) < 1000)
+        # Check that extrafocal isn't too much bigger than intrafocal
+        self.assertTrue(np.sum(extra.image > 0) - np.sum(intra.image > 0) < 1000)
 
         # Now simulate a pair with a constant height offset of +0.5mm
         x = np.linspace(-320, +320, 1000)
@@ -159,5 +159,5 @@ class TestModelUtils(unittest.TestCase):
             zkCoeff=[0],
         )
 
-        # Check that intrafocal is much larger than extrafocal
-        self.assertTrue(np.sum(intra.image > 0) - np.sum(extra.image > 0) > 1000)
+        # Check that extrafocal is much larger than intrafocal
+        self.assertTrue(np.sum(extra.image > 0) - np.sum(intra.image > 0) > 1000)


### PR DESCRIPTION
Here is the interpolated map:
<img width="649" height="608" alt="image" src="https://github.com/user-attachments/assets/33590ca8-d81c-46ff-b260-f03793b83ea6" />

You can confirm this map is in the CCS because of the visible e2v raft sticking out in the bottom right.

Compare this to the map provided by the camera team (notice this one is transposed from CCS):
<img width="1202" height="1056" alt="image" src="https://github.com/user-attachments/assets/2fbf2aec-de03-4450-9d07-d2b5ee055c2f" />

Here is a pair of donuts simulated with a constant focal plane height offset of +0.5mm. That positive offset moves the sensors away from the camera, i.e. towards the M1M3. That means the extrafocal donut is 0.5mm closer to focus, whereas the intrafocal donut is an additional 0.5mm farther from focus. You can see this borne out in the simulated images:
<img width="527" height="300" alt="image" src="https://github.com/user-attachments/assets/07f5623b-cd41-4a45-9793-c1fdae918c6b" />
