### PR TITLE
Correct FAM by shifting whole camera

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,10 +19,16 @@ def pytest_addoption(parser: Parser) -> None:
         default=False,
         help="Run WEP pipeline before all tests.",
     )
+    parser.addoption(
+        "--skip-pretest",
+        action="store_true",
+        default=False,
+        help="Skip pre-test WEP pipeline run.",
+    )
 
 
 def pytest_configure(config: Config) -> None:
-    if config.getoption("--run-pretest"):
+    if config.getoption("--run-pretest") and not config.getoption("--skip-pretest"):
         print("Running pre-test command...")
 
         # Set up the butler repository config
@@ -80,7 +86,7 @@ def pytest_configure(config: Config) -> None:
 
 
 def pytest_unconfigure(config: Config) -> None:
-    if config.getoption("--run-pretest"):
+    if config.getoption("--run-pretest") and not config.getoption("--skip-pretest"):
         print("Running cleanup...")
         for runName in [
             config.testInfo["runNameCwfs"],

--- a/doc/news/DM-53134.feature.md
+++ b/doc/news/DM-53134.feature.md
@@ -1,0 +1,1 @@
+Correctly handling FAM by shifting entire camera in batoid model.

--- a/policy/instruments/LsstCam.yaml
+++ b/policy/instruments/LsstCam.yaml
@@ -20,6 +20,7 @@ wavelength:
   z: 866.8e-9
   y: 973.9e-9
 batoidModelName: LSST_{band} # name used to load the Batoid model
+batoidOffsetOptic: Detector
 
 maskParams: # center and radius are in meters, theta in degrees
   M1:

--- a/python/lsst/ts/wep/estimation/wfAlgorithm.py
+++ b/python/lsst/ts/wep/estimation/wfAlgorithm.py
@@ -283,16 +283,16 @@ class WfAlgorithm(ABC):
         if startWithIntrinsic or returnWfDev:
             zkIntrinsicI1 = instrument.getIntrinsicZernikes(
                 *I1.fieldAngle,
-                I1.bandLabel,
-                nollIndices,
+                band=I1.bandLabel,
+                nollIndices=nollIndices,
             )
             zkIntrinsicI2 = (
                 None
                 if I2 is None
                 else instrument.getIntrinsicZernikes(
                     *I2.fieldAngle,
-                    I2.bandLabel,
-                    nollIndices,
+                    band=I2.bandLabel,
+                    nollIndices=nollIndices,
                 )
             )
 

--- a/python/lsst/ts/wep/imageMapper.py
+++ b/python/lsst/ts/wep/imageMapper.py
@@ -1267,7 +1267,7 @@ class ImageMapper:
             # Get the intrinsic Zernikes
             zkCoeff = self.instrument.getIntrinsicZernikes(
                 *image.fieldAngle,
-                image.bandLabel,
+                band=image.bandLabel,
             )
 
         # Get the image grid inside the pupil
@@ -1376,7 +1376,7 @@ class ImageMapper:
             # Get the intrinsic Zernikes
             zkCoeff = self.instrument.getIntrinsicZernikes(
                 *dummyImage.fieldAngle,
-                dummyImage.bandLabel,
+                band=dummyImage.bandLabel,
             )
 
         # Project the pupil onto the image plane
@@ -1445,7 +1445,7 @@ class ImageMapper:
             # Get the intrinsic Zernikes
             zkCoeff = self.instrument.getIntrinsicZernikes(
                 *image.fieldAngle,
-                image.bandLabel,
+                band=image.bandLabel,
             )
 
         # Create the image template
@@ -1513,7 +1513,7 @@ class ImageMapper:
             # Get the intrinsic Zernikes
             zkCoeff = self.instrument.getIntrinsicZernikes(
                 *image.fieldAngle,
-                image.bandLabel,
+                band=image.bandLabel,
             )
 
         # Get the image grid inside the pupil
@@ -1606,7 +1606,7 @@ class ImageMapper:
             # Get the intrinsic Zernikes
             zkCoeff = self.instrument.getIntrinsicZernikes(
                 *image.fieldAngle,
-                image.bandLabel,
+                band=image.bandLabel,
             )
 
         # Construct the forward mapping

--- a/python/lsst/ts/wep/instrument.py
+++ b/python/lsst/ts/wep/instrument.py
@@ -633,7 +633,11 @@ class Instrument:
     @property
     def batoidOffsetOptic(self) -> str | None:
         """The optic that is offset in the Batoid model."""
-        return self._batoidOffsetOptic
+        # Default to the detector if value not explicitly set
+        if self._batoidOffsetOptic is None and self.batoidModelName is not None:
+            return "Detector"
+        else:
+            return self._batoidOffsetOptic
 
     @batoidOffsetOptic.setter
     def batoidOffsetOptic(self, value: str | None) -> None:
@@ -734,6 +738,7 @@ class Instrument:
         self,
         xAngle: float,
         yAngle: float,
+        defocalType: DefocalType | None,
         band: BandLabel | str,
         jmax: int,
     ) -> np.ndarray:
@@ -747,6 +752,9 @@ class Instrument:
             The x-component of the field angle in degrees.
         yAngle : float
             The y-component of the field angle in degrees.
+        defocalType : DefocalType or str or None
+            The DefocalType Enum or corresponding string, specifying which side
+            of focus to model. If None, the model is not defocused.
         band : BandLabel or str, optional
             The BandLabel Enum or corresponding string, specifying which batoid
             model to load. Only relevant if self.batoidModelName contains
@@ -768,6 +776,13 @@ class Instrument:
         # If there is no batoid model, just return zeros
         if batoidModel is None:
             return np.zeros(jmax + 1)
+
+        # Offset the focal plane
+        if defocalType is not None:
+            defocalType = DefocalType(defocalType)
+            defocalSign = +1 if defocalType == DefocalType.Extra else -1
+            offset = [0, 0, defocalSign * self.defocalOffset]
+            batoidModel = batoidModel.withLocallyShiftedOptic(self.batoidOffsetOptic, offset)
 
         # Get the wavelength
         if len(self.wavelength) > 1:
@@ -794,6 +809,7 @@ class Instrument:
         self,
         xAngle: float,
         yAngle: float,
+        defocalType: DefocalType | None = None,
         band: BandLabel | str = BandLabel.REF,
         nollIndices: Sequence[int] = tuple(np.arange(4, 79)),
     ) -> np.ndarray:
@@ -805,6 +821,9 @@ class Instrument:
             The x-component of the field angle in degrees.
         yAngle : float
             The y-component of the field angle in degrees.
+        defocalType : DefocalType or str or None
+            The DefocalType Enum or corresponding string, specifying which side
+            of focus to model. If None, the model is not defocused.
         band : BandLabel or str, optional
             The BandLabel Enum or corresponding string, specifying which batoid
             model to load. Only relevant if self.batoidModelName contains
@@ -822,7 +841,13 @@ class Instrument:
         nollIndices = np.array(nollIndices)
 
         # Retrieve cached Zernikes
-        zk = self._getIntrinsicZernikesCached(xAngle, yAngle, band, max(nollIndices))
+        zk = self._getIntrinsicZernikesCached(
+            xAngle=xAngle,
+            yAngle=yAngle,
+            defocalType=defocalType,
+            band=band,
+            jmax=max(nollIndices),
+        )
 
         return zk[nollIndices]
 
@@ -831,7 +856,7 @@ class Instrument:
         self,
         xAngle: float,
         yAngle: float,
-        defocalType: DefocalType,
+        defocalType: DefocalType | None,
         band: BandLabel | str,
         jmax: int,
     ) -> np.ndarray:
@@ -843,9 +868,9 @@ class Instrument:
             The x-component of the field angle in degrees.
         yAngle : float
             The y-component of the field angle in degrees.
-        defocalType : DefocalType or str
+        defocalType : DefocalType or str or None
             The DefocalType Enum or corresponding string, specifying which side
-            of focus to model.
+            of focus to model. If None, the model is not defocused.
         band : BandLabel or str
             The BandLabel Enum or corresponding string, specifying which
             batoid model to load. Only relevant if self.batoidModelName
@@ -877,10 +902,11 @@ class Instrument:
             return np.zeros(jmax + 1)
 
         # Offset the focal plane
-        defocalType = DefocalType(defocalType)
-        defocalSign = +1 if defocalType == DefocalType.Extra else -1
-        offset = [0, 0, defocalSign * self.defocalOffset]
-        batoidModel = batoidModel.withLocallyShiftedOptic("Detector", offset)
+        if defocalType is not None:
+            defocalType = DefocalType(defocalType)
+            defocalSign = +1 if defocalType == DefocalType.Extra else -1
+            offset = [0, 0, defocalSign * self.defocalOffset]
+            batoidModel = batoidModel.withLocallyShiftedOptic(self.batoidOffsetOptic, offset)
 
         # Get the wavelength
         if len(self.wavelength) > 1:
@@ -909,7 +935,7 @@ class Instrument:
         self,
         xAngle: float,
         yAngle: float,
-        defocalType: DefocalType,
+        defocalType: DefocalType | None,
         band: BandLabel | str = BandLabel.REF,
         nollIndicesModel: Sequence = tuple(np.arange(4, 79)),
         nollIndicesIntr: Sequence = tuple(np.arange(4, 79)),
@@ -922,9 +948,9 @@ class Instrument:
             The x-component of the field angle in degrees.
         yAngle : float
             The y-component of the field angle in degrees.
-        defocalType : DefocalType or str
+        defocalType : DefocalType or str or None
             The DefocalType Enum or corresponding string, specifying which side
-            of focus to model.
+            of focus to model. If None, the model is not defocused.
         band : BandLabel or str, optional
             The BandLabel Enum or corresponding string, specifying which
             batoid model to load. Only relevant if self.batoidModelName
@@ -952,19 +978,20 @@ class Instrument:
 
         # Get zernikeTA
         zkTA = self._getIntrinsicZernikesTACached(
-            xAngle,
-            yAngle,
-            defocalType,
-            band,
-            max(nollIndicesModel),
+            xAngle=xAngle,
+            yAngle=yAngle,
+            defocalType=defocalType,
+            band=band,
+            jmax=max(nollIndicesModel),
         )
 
         # Get regular intrinsic zernikes
         zk = self._getIntrinsicZernikesCached(
-            xAngle,
-            yAngle,
-            band,
-            max(nollIndicesIntr),
+            xAngle=xAngle,
+            yAngle=yAngle,
+            defocalType=defocalType,
+            band=band,
+            jmax=max(nollIndicesIntr),
         )
 
         # Subtract intrinsics from zernikeTA

--- a/python/lsst/ts/wep/instrument.py
+++ b/python/lsst/ts/wep/instrument.py
@@ -989,7 +989,7 @@ class Instrument:
         zk = self._getIntrinsicZernikesCached(
             xAngle=xAngle,
             yAngle=yAngle,
-            defocalType=defocalType,
+            defocalType=None,
             band=band,
             jmax=max(nollIndicesIntr),
         )

--- a/python/lsst/ts/wep/utils/plotUtils.py
+++ b/python/lsst/ts/wep/utils/plotUtils.py
@@ -429,7 +429,7 @@ def plotMapperResiduals(
     uImage, vImage, *_ = mapper._constructForwardMap(
         uPupil,
         vPupil,
-        mapper.instrument.getIntrinsicZernikes(*angle, band, jmax=22),
+        mapper.instrument.getIntrinsicZernikes(*angle, band=band, nollIndices=np.arange(4, 23)),
         Image(np.zeros((1, 1)), angle, defocalType, band),
     )
 

--- a/tests/task/test_cutOutDonutsBase.py
+++ b/tests/task/test_cutOutDonutsBase.py
@@ -460,9 +460,9 @@ class TestCutOutDonutsBase(lsst.utils.tests.TestCase):
         self.assertTrue(allowed_values.issuperset(unique_values))
 
         # test the calculation of SN
-        sn_values = [2149.093503846915, 2160.668317852145, 2041.9917562475855]
+        sn_values = [2152.969905, 2574.566976, 2981.683746]
         sn_calculated = donutStamps.metadata.getArray("SN")
-        np.testing.assert_allclose(np.sort(np.array(sn_values)), np.sort(np.array(sn_calculated)), rtol=1e-3)
+        np.testing.assert_allclose(np.sort(np.array(sn_calculated)), np.sort(np.array(sn_values)), rtol=1e-3)
 
     def testFilterBadRecentering(self) -> None:
         maxRecenter = 25

--- a/tests/task/test_donutStampSelectorTask.py
+++ b/tests/task/test_donutStampSelectorTask.py
@@ -142,7 +142,6 @@ class TestDonutStampSelectorTask(lsst.utils.tests.TestCase):
         # test defaults
         selection = self.task.selectStamps(donutStampsIntra)
         donutsQuality = selection.donutsQuality
-        print(donutsQuality)
 
         # by default, config.selectWithEntropy is False,
         # so we select all donuts
@@ -196,7 +195,7 @@ class TestDonutStampSelectorTask(lsst.utils.tests.TestCase):
         task = DonutStampSelectorTask(config=self.config, name="SN Task")
         selection = task.selectStamps(donutStampsIntra)
         donutsQuality = selection.donutsQuality
-        self.assertEqual(np.sum(donutsQuality["SN_SELECT"]), 2)
+        self.assertEqual(np.sum(donutsQuality["SN_SELECT"]), 3)
 
         # test that the SN of selected donuts is indeed above the threshold
         for v in donutsQuality["SN"][donutsQuality["SN_SELECT"]]:

--- a/tests/test_imageMapper.py
+++ b/tests/test_imageMapper.py
@@ -668,7 +668,7 @@ class TestImageMapper(unittest.TestCase):
                 uImage, vImage, *_ = mapper._constructForwardMap(
                     uPupil,
                     vPupil,
-                    inst.getIntrinsicZernikes(*angle, band),
+                    inst.getIntrinsicZernikes(*angle, band=band),
                     None,
                     Image(np.zeros((1, 1)), angle, dfType, band),
                 )

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -243,6 +243,21 @@ class TestInstrument(unittest.TestCase):
         for key in keys:
             self.assertEqual(getattr(lsst, key), getattr(comcam, key))
 
+    def test_intrinsicZernikesDefocused(self) -> None:
+        inst = Instrument()
+        z4_intra = inst.getIntrinsicZernikes(-0.3, 1.2, defocalType="intra", nollIndices=[4])
+        z4_extra = inst.getIntrinsicZernikes(-0.3, 1.2, defocalType="extra", nollIndices=[4])
+        self.assertTrue(np.isclose(-z4_extra, z4_intra, rtol=1e-2))
+
+    def test_offsetCamera(self) -> None:
+        """Just test shifting camera vs detector gives different intrinsics."""
+        inst1 = Instrument()
+        inst2 = Instrument(batoidOffsetOptic="LSSTCamera")
+        for dftype in ["intra", "extra"]:
+            zk_1 = inst1.getIntrinsicZernikes(0.3, 0.6, defocalType=dftype)
+            zk_2 = inst2.getIntrinsicZernikes(0.3, 0.6, defocalType=dftype)
+            self.assertFalse(np.allclose(zk_1, zk_2, rtol=1e-2))
+
 
 if __name__ == "__main__":
     # Do the unit test


### PR DESCRIPTION
Let's make sure our plots of the difference in intrinsics match.

Here I am plotting
- extrafocal
- LSSTCam shift - Detector shift
- x and y axes are field angles

<img width="604" height="612" alt="image" src="https://github.com/user-attachments/assets/3dbd3344-3202-4e20-a740-059ba12b2b46" />

This is a pretty close match to the plot you shared on slack (copied here), where you stated all higher-order residuals are close to zero:
<img width="1600" height="1100" alt="image" src="https://github.com/user-attachments/assets/6f77ce50-10d1-42cb-bd92-fad1fafcc385" />

The first thing to notice is our z4 residual has opposite signs. I assume you plotted Detector shift - LSSTCam shift? The other thing is we don't have the same parities for z5 and z8. This is probably related to coordinate systems?