### PR TITLE
Fix bug with intrinsic Zernikes in unpaired calc Zernikes task

### DIFF
--- a/doc/news/DM-53632.bugfix.md
+++ b/doc/news/DM-53632.bugfix.md
@@ -1,0 +1,1 @@
+Fixed bug with intrinsics in unpaired Zernike calculation task.

--- a/python/lsst/ts/wep/task/calcZernikesTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesTask.py
@@ -250,7 +250,7 @@ class CalcZernikesTask(pipeBase.PipelineTask, metaclass=abc.ABCMeta):
         if stamp is None:
             fieldAngle = np.array(np.nan, dtype=pos2f_dtype) * u.deg
             centroid = np.array((np.nan, np.nan), dtype=pos2f_dtype) * u.pixel
-            intrinsics = np.full_like(self.nollIndices, np.nan) * u.micron
+            intrinsics = np.full(len(self.nollIndices), np.nan) * u.micron
         else:
             fieldAngle = np.array(stamp.calcFieldXY(), dtype=pos2f_dtype) * u.deg
             centroid = (


### PR DESCRIPTION
The problem was with `np.full_like(self.nollIndices, np.nan)`. self.nollIndices was filled with integers, so it tried to cast np.nan to an integer, which results in bad, unpredictable behavior.

I wrote a test to catch this -- specifically by setting the Z4 intrinsic to a known value, making sure it was reproduced in the Zernike table. Then I implemented the fix so the test would pass.