### PR TITLE
Tickets/DM-54173: fix refitWcsTask

### DIFF
--- a/doc/news/DM-54173.bugfix.md
+++ b/doc/news/DM-54173.bugfix.md
@@ -1,0 +1,2 @@
+Add ``_clipDonutCatalogToDetector`` to filter donuts outside the detector bounding box on all code paths.
+Fix early-return paths missing detector name column and visit info metadata.


### PR DESCRIPTION
Adding clipping sources to detector boundary, so that even if donut selection is off (eg. to return as many sources as possible), the resulting catalog is still within the bounding box. Snapshot of  a post_isr_image with before / after changes, and reproducible pipetask call,  in the ticket comments https://rubinobs.atlassian.net/browse/DM-54173