### PR TITLE
Tickets/dm 53212

### DIFF
--- a/doc/news/DM-53578.feature.md
+++ b/doc/news/DM-53578.feature.md
@@ -1,0 +1,1 @@
+Make reassignCwfsCutoutsTask not reassign cutouts to extra-focal CWFS detectors when run by RA in the custom Quantum Graph Builder scenario.

--- a/python/lsst/ts/wep/estimation/aiDonut.py
+++ b/python/lsst/ts/wep/estimation/aiDonut.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import os
 import numpy as np
 import torch
 
@@ -64,7 +65,7 @@ class AiDonutAlgorithm(WfAlgorithm):
         device: str = "cpu",
     ) -> None:
         self.device = device
-        self.modelPath = modelPath
+        self.modelPath = os.path.expandvars(modelPath)
 
     @property
     def requiresPairs(self) -> bool:

--- a/python/lsst/ts/wep/estimation/aiDonut.py
+++ b/python/lsst/ts/wep/estimation/aiDonut.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
+
 import numpy as np
 import torch
 

--- a/python/lsst/ts/wep/task/calcZernikesTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesTask.py
@@ -72,7 +72,7 @@ class CalcZernikesTaskConnections(
         storageClass="StampsBase",
         name="donutStampsIntra",
     )
-    intrinsicTables = connectionTypes.Input(
+    intrinsicTables = connectionTypes.PrerequisiteInput(
         doc="Intrinsic Zernike Map for the instrument",
         dimensions=("detector", "instrument", "physical_filter"),
         storageClass="ArrowAstropy",

--- a/python/lsst/ts/wep/task/calcZernikesTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesTask.py
@@ -65,10 +65,14 @@ def lookupIntrinsicTables(
 ) -> list[DatasetRef]:
     """Assumes that the dataId is always for the extra focal at present
     """
-    ref1 = registry.findDataset(datasetType, dataId, collections=collections)
-    dataId2 = DataCoordinate.standardize(dataId, detector=dataId["detector"] + 1)
-    ref2 = registry.findDataset(datasetType, dataId2, collections=collections)
-    return [ref1, ref2]
+    detector = dataId["detector"]
+    isCornerChip = (detector in intra_focal_ids) or (detector in extra_focal_ids)
+
+    refs = [registry.findDataset(datasetType, dataId, collections=collections)]
+    if isCornerChip:  # we're running a CWFS pair, not a FAM image
+        dataId2 = DataCoordinate.standardize(dataId, detector=dataId["detector"] + 1)
+        refs.append(registry.findDataset(datasetType, dataId2, collections=collections))
+    return refs
 
 
 class CalcZernikesTaskConnections(

--- a/python/lsst/ts/wep/task/calcZernikesTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesTask.py
@@ -27,7 +27,7 @@ __all__ = [
 
 import abc
 from itertools import zip_longest
-from typing import Any, cast
+from typing import Any, cast, Sequence
 
 import astropy.units as u
 import numpy as np
@@ -37,7 +37,8 @@ from scipy.interpolate import LinearNDInterpolator, RegularGridInterpolator
 
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
-from lsst.daf.butler import DataCoordinate
+from lsst.daf.butler import DataCoordinate, DatasetType, Registry, DatasetRef
+
 from lsst.pipe.base import (
     InputQuantizedConnection,
     OutputQuantizedConnection,
@@ -54,6 +55,20 @@ from lsst.utils.timer import timeMethod
 pos2f_dtype = np.dtype([("x", "<f4"), ("y", "<f4")])
 intra_focal_ids = set([192, 196, 200, 204])
 extra_focal_ids = set([191, 195, 199, 203])
+
+
+def lookupIntrinsicTables(
+    datasetType: DatasetType,
+    registry: Registry,
+    dataId: DataCoordinate,
+    collections: Sequence[str]
+) -> list[DatasetRef]:
+    """Assumes that the dataId is always for the extra focal at present
+    """
+    ref1 = registry.findDataset(datasetType, dataId, collections=collections)
+    dataId2 = DataCoordinate.standardize(dataId, detector=dataId["detector"] + 1)
+    ref2 = registry.findDataset(datasetType, dataId2, collections=collections)
+    return [ref1, ref2]
 
 
 class CalcZernikesTaskConnections(
@@ -78,6 +93,7 @@ class CalcZernikesTaskConnections(
         storageClass="ArrowAstropy",
         name="intrinsic_aberrations_temp",
         multiple=True,
+        lookupFunction=lookupIntrinsicTables,
     )
     outputZernikesRaw = connectionTypes.Output(
         doc="Zernike Coefficients from all donuts",
@@ -103,27 +119,6 @@ class CalcZernikesTaskConnections(
         storageClass="AstropyQTable",
         name="donutQualityTable",
     )
-
-    def adjust_all_quanta(self, adjuster: pipeBase.QuantaAdjuster) -> None:
-        """Add intrinsicTables inputs from intra-focal donuts to the
-        tasks running on extra-focal data ids."""
-        to_do = set(adjuster.iter_data_ids())
-        seen = set()
-        while to_do:
-            data_id = to_do.pop()
-            if data_id["detector"] in extra_focal_ids:
-                intra_focal_data_id = DataCoordinate.standardize(
-                    data_id, detector=int(data_id["detector"]) + 1
-                )
-
-                assert intra_focal_data_id in seen or intra_focal_data_id in to_do, (
-                    f"DataId {intra_focal_data_id} not found in seen or to_do sets."
-                )
-
-                intra_inputs = adjuster.get_inputs(intra_focal_data_id)
-                adjuster.add_input(data_id, "intrinsicTables", intra_inputs["intrinsicTables"][0])
-            elif data_id["detector"] in intra_focal_ids:
-                seen.add(data_id)
 
 
 class CalcZernikesTaskConfig(

--- a/python/lsst/ts/wep/task/calcZernikesTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesTask.py
@@ -27,7 +27,7 @@ __all__ = [
 
 import abc
 from itertools import zip_longest
-from typing import Any, cast, Sequence
+from typing import Any, Sequence, cast
 
 import astropy.units as u
 import numpy as np
@@ -37,8 +37,7 @@ from scipy.interpolate import LinearNDInterpolator, RegularGridInterpolator
 
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
-from lsst.daf.butler import DataCoordinate, DatasetType, Registry, DatasetRef
-
+from lsst.daf.butler import DataCoordinate, DatasetRef, DatasetType, Registry
 from lsst.pipe.base import (
     InputQuantizedConnection,
     OutputQuantizedConnection,
@@ -58,19 +57,15 @@ extra_focal_ids = set([191, 195, 199, 203])
 
 
 def lookupIntrinsicTables(
-    datasetType: DatasetType,
-    registry: Registry,
-    dataId: DataCoordinate,
-    collections: Sequence[str]
-) -> list[DatasetRef]:
-    """Assumes that the dataId is always for the extra focal at present
-    """
+    datasetType: DatasetType, registry: Registry, dataId: DataCoordinate, collections: Sequence[str]
+) -> list[DatasetRef | None]:
+    """Assumes that the dataId is always for the extra focal at present"""
     detector = dataId["detector"]
     isCornerChip = (detector in intra_focal_ids) or (detector in extra_focal_ids)
 
     refs = [registry.findDataset(datasetType, dataId, collections=collections)]
     if isCornerChip:  # we're running a CWFS pair, not a FAM image
-        dataId2 = DataCoordinate.standardize(dataId, detector=dataId["detector"] + 1)
+        dataId2 = DataCoordinate.standardize(dataId, detector=int(dataId["detector"]) + 1)
         refs.append(registry.findDataset(datasetType, dataId2, collections=collections))
     return refs
 
@@ -97,7 +92,7 @@ class CalcZernikesTaskConnections(
         storageClass="ArrowAstropy",
         name="intrinsic_aberrations_temp",
         multiple=True,
-        lookupFunction=lookupIntrinsicTables,
+        lookupFunction=lookupIntrinsicTables,  # type: ignore
     )
     outputZernikesRaw = connectionTypes.Output(
         doc="Zernike Coefficients from all donuts",

--- a/python/lsst/ts/wep/task/calcZernikesUnpairedTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesUnpairedTask.py
@@ -58,7 +58,7 @@ class CalcZernikesUnpairedTaskConnections(
         storageClass="StampsBase",
         name="donutStamps",
     )
-    intrinsicTable = connectionTypes.Input(
+    intrinsicTable = connectionTypes.PrerequisiteInput(
         doc="Intrinsic Zernike Map for the instrument",
         dimensions=("detector", "instrument", "physical_filter"),
         storageClass="ArrowAstropy",

--- a/python/lsst/ts/wep/task/calcZernikesUnpairedTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesUnpairedTask.py
@@ -34,6 +34,18 @@ from lsst.ts.wep.task.calcZernikesTask import CalcZernikesTask, CalcZernikesTask
 from lsst.ts.wep.task.donutStamps import DonutStamps
 from lsst.utils.timer import timeMethod
 
+def lookupIntrinsicTables(
+    datasetType: DatasetType,
+    registry: Registry,
+    dataId: DataCoordinate,
+    collections: Sequence[str]
+) -> list[DatasetRef]:
+    detector = dataId["detector"]
+    isCornerChip = (detector in intra_focal_ids) or (detector in extra_focal_ids)
+
+    refs = [registry.findDataset(datasetType, dataId, collections=collections)]
+    return refs
+
 
 class CalcZernikesUnpairedTaskConnections(
     pipeBase.PipelineTaskConnections,
@@ -50,6 +62,7 @@ class CalcZernikesUnpairedTaskConnections(
         dimensions=("detector", "instrument", "physical_filter"),
         storageClass="ArrowAstropy",
         name="intrinsic_aberrations_temp",
+        lookupFunction=lookupIntrinsicTables,
     )
     outputZernikesRaw = connectionTypes.Output(
         doc="Zernike Coefficients from all donuts",

--- a/python/lsst/ts/wep/task/calcZernikesUnpairedTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesUnpairedTask.py
@@ -25,6 +25,7 @@ __all__ = [
     "CalcZernikesUnpairedTask",
 ]
 
+from typing import Sequence
 import numpy as np
 from astropy.table import QTable, Table
 
@@ -33,6 +34,8 @@ from lsst.pipe.base import connectionTypes
 from lsst.ts.wep.task.calcZernikesTask import CalcZernikesTask, CalcZernikesTaskConfig
 from lsst.ts.wep.task.donutStamps import DonutStamps
 from lsst.utils.timer import timeMethod
+from lsst.daf.butler import DatasetType, Registry, DataCoordinate, DatasetRef
+
 
 def lookupIntrinsicTables(
     datasetType: DatasetType,
@@ -40,8 +43,6 @@ def lookupIntrinsicTables(
     dataId: DataCoordinate,
     collections: Sequence[str]
 ) -> list[DatasetRef]:
-    detector = dataId["detector"]
-    isCornerChip = (detector in intra_focal_ids) or (detector in extra_focal_ids)
 
     refs = [registry.findDataset(datasetType, dataId, collections=collections)]
     return refs

--- a/python/lsst/ts/wep/task/calcZernikesUnpairedTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesUnpairedTask.py
@@ -26,24 +26,21 @@ __all__ = [
 ]
 
 from typing import Sequence
+
 import numpy as np
 from astropy.table import QTable, Table
 
 import lsst.pipe.base as pipeBase
+from lsst.daf.butler import DataCoordinate, DatasetRef, DatasetType, Registry
 from lsst.pipe.base import connectionTypes
 from lsst.ts.wep.task.calcZernikesTask import CalcZernikesTask, CalcZernikesTaskConfig
 from lsst.ts.wep.task.donutStamps import DonutStamps
 from lsst.utils.timer import timeMethod
-from lsst.daf.butler import DatasetType, Registry, DataCoordinate, DatasetRef
 
 
 def lookupIntrinsicTables(
-    datasetType: DatasetType,
-    registry: Registry,
-    dataId: DataCoordinate,
-    collections: Sequence[str]
-) -> list[DatasetRef]:
-
+    datasetType: DatasetType, registry: Registry, dataId: DataCoordinate, collections: Sequence[str]
+) -> list[DatasetRef | None]:
     refs = [registry.findDataset(datasetType, dataId, collections=collections)]
     return refs
 
@@ -63,7 +60,7 @@ class CalcZernikesUnpairedTaskConnections(
         dimensions=("detector", "instrument", "physical_filter"),
         storageClass="ArrowAstropy",
         name="intrinsic_aberrations_temp",
-        lookupFunction=lookupIntrinsicTables,
+        lookupFunction=lookupIntrinsicTables,  # type: ignore
     )
     outputZernikesRaw = connectionTypes.Output(
         doc="Zernike Coefficients from all donuts",

--- a/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
@@ -167,10 +167,6 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
         }
         exposureHandleDict = {v.dataId["exposure"]: v for v in inputRefs.exposures}
         donutCatalogHandleDict = {v.dataId["visit"]: v for v in inputRefs.donutCatalog}
-        donutStampsIntraHandleDict = {v.dataId["visit"]: v for v in outputRefs.donutStampsIntra}
-        donutStampsExtraHandleDict = {v.dataId["visit"]: v for v in outputRefs.donutStampsExtra}
-        donutTableIntraHandleDict = {v.dataId["visit"]: v for v in outputRefs.donutTableIntra}
-        donutTableExtraHandleDict = {v.dataId["visit"]: v for v in outputRefs.donutTableExtra}
 
         if hasattr(inputRefs, "donutVisitPairTable"):
             pairs = self.pairer.run(visitInfoDict, butlerQC.get(inputRefs.donutVisitPairTable))
@@ -180,15 +176,15 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
             exposures = butlerQC.get([exposureHandleDict[k] for k in [pair.intra, pair.extra]])
             donutCats = butlerQC.get([donutCatalogHandleDict[k] for k in [pair.intra, pair.extra]])
             outputs = self.run(exposures, donutCats, camera)
-            butlerQC.put(outputs.donutStampsExtra, donutStampsExtraHandleDict[pair.extra])
+            butlerQC.put(outputs.donutStampsExtra, outputRefs.donutTableExtra.dataId["visit"])
             butlerQC.put(
                 outputs.donutStampsIntra,
-                donutStampsIntraHandleDict[pair.extra],  # Intentionally use extra id for intra stamps here
+                outputRefs.donutTableExtra.dataId["visit"],  # Intentionally use extra id for intra stamps here
             )
-            butlerQC.put(outputs.donutTableExtra, donutTableExtraHandleDict[pair.extra])
+            butlerQC.put(outputs.donutTableExtra, outputRefs.donutTableExtra.dataId["visit"])
             butlerQC.put(
                 outputs.donutTableIntra,
-                donutTableIntraHandleDict[pair.extra],  # Intentionally use extra id for intra tables here
+                outputRefs.donutTableExtra.dataId["visit"],  # Intentionally use extra id for intra tables here
             )
 
     def assignExtraIntraIdx(self, focusZVal0: float, focusZVal1: float, cameraName: str) -> tuple[int, int]:

--- a/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
@@ -81,12 +81,14 @@ class CutOutDonutsScienceSensorTaskConnections(
         dimensions=("visit", "detector", "instrument"),
         storageClass="StampsBase",
         name="donutStampsExtra",
+        multiple=True
     )
     donutStampsIntra = ct.Output(
         doc="Intra-focal Donut Postage Stamp Images",
         dimensions=("visit", "detector", "instrument"),
         storageClass="StampsBase",
         name="donutStampsIntra",
+        multiple=True
     )
     donutTablesIntra = ct.Output(
         doc="Intra-focal Donut Postage Stamp Table",

--- a/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
@@ -81,14 +81,24 @@ class CutOutDonutsScienceSensorTaskConnections(
         dimensions=("visit", "detector", "instrument"),
         storageClass="StampsBase",
         name="donutStampsExtra",
-        multiple=True,
     )
     donutStampsIntra = ct.Output(
         doc="Intra-focal Donut Postage Stamp Images",
         dimensions=("visit", "detector", "instrument"),
         storageClass="StampsBase",
         name="donutStampsIntra",
-        multiple=True,
+    )
+    donutTableIntra = ct.Output(
+        doc="Intra-focal Donut Postage Stamp Table",
+        dimensions=("visit", "detector", "instrument"),
+        storageClass="AstropyQTable",
+        name="donutTableIntra",
+    )
+    donutTableExtra = ct.Output(
+        doc="Extra-focal Donut Postage Stamp Table",
+        dimensions=("visit", "detector", "instrument"),
+        storageClass="AstropyQTable",
+        name="donutTableExtra",
     )
 
     def __init__(self, *, config: Any | None = None) -> None:
@@ -159,6 +169,8 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
         donutCatalogHandleDict = {v.dataId["visit"]: v for v in inputRefs.donutCatalog}
         donutStampsIntraHandleDict = {v.dataId["visit"]: v for v in outputRefs.donutStampsIntra}
         donutStampsExtraHandleDict = {v.dataId["visit"]: v for v in outputRefs.donutStampsExtra}
+        donutTableIntraHandleDict = {v.dataId["visit"]: v for v in outputRefs.donutTableIntra}
+        donutTableExtraHandleDict = {v.dataId["visit"]: v for v in outputRefs.donutTableExtra}
 
         if hasattr(inputRefs, "donutVisitPairTable"):
             pairs = self.pairer.run(visitInfoDict, butlerQC.get(inputRefs.donutVisitPairTable))
@@ -172,6 +184,11 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
             butlerQC.put(
                 outputs.donutStampsIntra,
                 donutStampsIntraHandleDict[pair.extra],  # Intentionally use extra id for intra stamps here
+            )
+            butlerQC.put(outputs.donutTableExtra, donutTableExtraHandleDict[pair.extra])
+            butlerQC.put(
+                outputs.donutTableIntra,
+                donutTableIntraHandleDict[pair.extra],  # Intentionally use extra id for intra tables here
             )
 
     def assignExtraIntraIdx(self, focusZVal0: float, focusZVal1: float, cameraName: str) -> tuple[int, int]:
@@ -290,4 +307,6 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
         return pipeBase.Struct(
             donutStampsExtra=donutStampsExtra,
             donutStampsIntra=donutStampsIntra,
+            donutTableExtra=donutCatalog[extraExpIdx],
+            donutTableIntra=donutCatalog[intraExpIdx],
         )

--- a/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
@@ -169,10 +169,6 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
         }
         exposureHandleDict = {v.dataId["exposure"]: v for v in inputRefs.exposures}
         donutCatalogHandleDict = {v.dataId["visit"]: v for v in inputRefs.donutCatalog}
-        donutStampsIntraHandleDict = {v.dataId["visit"]: v for v in outputRefs.donutStampsIntra}
-        donutStampsExtraHandleDict = {v.dataId["visit"]: v for v in outputRefs.donutStampsExtra}
-        donutTablesIntraHandleDict = {v.dataId["visit"]: v for v in outputRefs.donutTablesIntra}
-        donutTablesExtraHandleDict = {v.dataId["visit"]: v for v in outputRefs.donutTablesExtra}
 
         if hasattr(inputRefs, "donutVisitPairTable"):
             pairs = self.pairer.run(visitInfoDict, butlerQC.get(inputRefs.donutVisitPairTable))
@@ -182,16 +178,18 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
             exposures = butlerQC.get([exposureHandleDict[k] for k in [pair.intra, pair.extra]])
             donutCats = butlerQC.get([donutCatalogHandleDict[k] for k in [pair.intra, pair.extra]])
             outputs = self.run(exposures, donutCats, camera)
-            butlerQC.put(outputs.donutStampsExtra, donutStampsExtraHandleDict[pair.extra])
-            butlerQC.put(
-                outputs.donutStampsIntra,
-                donutStampsIntraHandleDict[pair.extra]  # Intentionally use extra id for intra stamps here
-            )
-            butlerQC.put(outputs.donutTableExtra, donutTablesExtraHandleDict[pair.extra])
-            butlerQC.put(
-                outputs.donutTableIntra,
-                donutTablesIntraHandleDict[pair.extra]  # Intentionally use extra id for intra tables here
-            )
+
+            # Intentionally use extra id for intra stamps here
+            (donutStampsIntraRef,) = [ref for ref in outputRefs.donutStampsIntra if ref.dataId["visit"] == pair.extra]
+            (donutStampsExtraRef,) = [ref for ref in outputRefs.donutStampsExtra if ref.dataId["visit"] == pair.extra]
+            butlerQC.put(outputs.donutStampsExtra, donutStampsExtraRef)
+            butlerQC.put(outputs.donutStampsIntra, donutStampsIntraRef)
+
+            # Intentionally use extra id for intra stamps here
+            (donutTableIntraRef,) = [ref for ref in outputRefs.donutTablesIntra if ref.dataId["visit"] == pair.extra]
+            (donutTableExtraRef,) = [ref for ref in outputRefs.donutTablesExtra if ref.dataId["visit"] == pair.extra]
+            butlerQC.put(outputs.donutTableExtra, donutTableExtraRef)
+            butlerQC.put(outputs.donutTableIntra, donutTableIntraRef)
 
     def assignExtraIntraIdx(self, focusZVal0: float, focusZVal1: float, cameraName: str) -> tuple[int, int]:
         """

--- a/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
@@ -56,6 +56,19 @@ class CutOutDonutsScienceSensorTaskConnections(
         storageClass="Exposure",
         name="post_isr_image",
         multiple=True,
+        minimum=2,
+    )
+    donutCatalog = ct.Input(
+        doc="Donut Locations",
+        dimensions=(
+            "visit",
+            "detector",
+            "instrument",
+        ),
+        storageClass="AstropyQTable",
+        name="donutTable",
+        multiple=True,
+        minimum=2,
     )
     donutVisitPairTable = ct.Input(
         doc="Visit pair table",

--- a/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
@@ -81,28 +81,28 @@ class CutOutDonutsScienceSensorTaskConnections(
         dimensions=("visit", "detector", "instrument"),
         storageClass="StampsBase",
         name="donutStampsExtra",
-        multiple=True
+        multiple=True,
     )
     donutStampsIntra = ct.Output(
         doc="Intra-focal Donut Postage Stamp Images",
         dimensions=("visit", "detector", "instrument"),
         storageClass="StampsBase",
         name="donutStampsIntra",
-        multiple=True
+        multiple=True,
     )
     donutTablesIntra = ct.Output(
         doc="Intra-focal Donut Postage Stamp Table",
         dimensions=("visit", "detector", "instrument"),
         storageClass="AstropyQTable",
         name="donutTableIntra",
-        multiple=True
+        multiple=True,
     )
     donutTablesExtra = ct.Output(
         doc="Extra-focal Donut Postage Stamp Table",
         dimensions=("visit", "detector", "instrument"),
         storageClass="AstropyQTable",
         name="donutTableExtra",
-        multiple=True
+        multiple=True,
     )
 
     def __init__(self, *, config: Any | None = None) -> None:
@@ -182,14 +182,22 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
             outputs = self.run(exposures, donutCats, camera)
 
             # Intentionally use extra id for intra stamps here
-            (donutStampsIntraRef,) = [ref for ref in outputRefs.donutStampsIntra if ref.dataId["visit"] == pair.extra]
-            (donutStampsExtraRef,) = [ref for ref in outputRefs.donutStampsExtra if ref.dataId["visit"] == pair.extra]
+            (donutStampsIntraRef,) = [
+                ref for ref in outputRefs.donutStampsIntra if ref.dataId["visit"] == pair.extra
+            ]
+            (donutStampsExtraRef,) = [
+                ref for ref in outputRefs.donutStampsExtra if ref.dataId["visit"] == pair.extra
+            ]
             butlerQC.put(outputs.donutStampsExtra, donutStampsExtraRef)
             butlerQC.put(outputs.donutStampsIntra, donutStampsIntraRef)
 
             # Intentionally use extra id for intra stamps here
-            (donutTableIntraRef,) = [ref for ref in outputRefs.donutTablesIntra if ref.dataId["visit"] == pair.extra]
-            (donutTableExtraRef,) = [ref for ref in outputRefs.donutTablesExtra if ref.dataId["visit"] == pair.extra]
+            (donutTableIntraRef,) = [
+                ref for ref in outputRefs.donutTablesIntra if ref.dataId["visit"] == pair.extra
+            ]
+            (donutTableExtraRef,) = [
+                ref for ref in outputRefs.donutTablesExtra if ref.dataId["visit"] == pair.extra
+            ]
             butlerQC.put(outputs.donutTableExtra, donutTableExtraRef)
             butlerQC.put(outputs.donutTableIntra, donutTableIntraRef)
 

--- a/python/lsst/ts/wep/task/reassignCwfsCutoutsTask.py
+++ b/python/lsst/ts/wep/task/reassignCwfsCutoutsTask.py
@@ -27,8 +27,8 @@ __all__ = [
 
 from typing import Any
 
-import lsst.pipe.base as pipeBase
 import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
 from lsst.daf.butler import DataCoordinate
 from lsst.pipe.base import connectionTypes
 
@@ -40,6 +40,8 @@ class ReassignCwfsCutoutsTaskConnections(
     pipeBase.PipelineTaskConnections,
     dimensions=("visit", "detector", "instrument"),  # type: ignore
 ):
+    config: Any  # For adjust_all_quanta which needs config
+
     donutStampsIn = connectionTypes.Input(
         doc="Donut Postage Stamp Images with either Intra-focal or Extra-focal detector id.",
         dimensions=("visit", "detector", "instrument"),

--- a/tests/testData/gen3TestRepo/gen3.sqlite3
+++ b/tests/testData/gen3TestRepo/gen3.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8bc3b5ad02d5884f98618b2f6b9f8e90ce0b443baa7e428a548efedfd885182
-size 2404352
+oid sha256:61e931ddf07933f27275fbfdb9f59d83c5e1713c02fd2659b244491566821d7f
+size 2408448


### PR DESCRIPTION
This PR improves how intrinsic Zernike tables are looked up (now PrerequisiteInputs with a proper lookup function). It moves donut table pairing out of donut_viz and adds intra and extra donut table outputs to the science sensor cutout task. It adds code for a Rapid Analysis custom QG builder workflow that enables the intra and extra-focal wavefront sensors to run in parallel in RA.

This will require changes to the RapidAnalysis pipelines that are contained in the corresponding PR on `donut_viz`  (https://github.com/lsst-ts/donut_viz/pull/68) but non-RA pipelines will not need changes. This code is already the base code in `deploy-bts` and `deploy-summit` so has been tested and is already running in production.