### PR TITLE
Fixed bug where intrinsics interpolation depended on order of points in the tables.

### DIFF
--- a/doc/news/fix_intrinsic_interp.bugfix.rst
+++ b/doc/news/fix_intrinsic_interp.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug in intrinsic interpolation (by removing RegularGridInterpolator) in which results depended on the order in which the points were stored in the intrinsic tables.

--- a/python/lsst/ts/wep/task/calcZernikesTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesTask.py
@@ -33,7 +33,7 @@ import astropy.units as u
 import numpy as np
 from astropy.stats import sigma_clip
 from astropy.table import QTable, Table, vstack
-from scipy.interpolate import LinearNDInterpolator, RegularGridInterpolator
+from scipy.interpolate import LinearNDInterpolator
 
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
@@ -212,21 +212,13 @@ class CalcZernikesTask(pipeBase.PipelineTask, metaclass=abc.ABCMeta):
         # Extract arrays of field angle (deg)
         x = intrinsicTable["x"].to("deg").value
         y = intrinsicTable["y"].to("deg").value
-        x_grid = np.unique(x)
-        y_grid = np.unique(y)
 
         # Extract intrinsic Zernike coefficients (microns)
         zkTable = intrinsicTable[[f"Z{i}" for i in self.nollIndices]]
         zks = np.column_stack([zkTable[col].to("um").value for col in zkTable.colnames])
 
-        # Create the interpolator
-        if (len(x_grid) * len(y_grid)) == len(intrinsicTable):
-            # If the grid is regular and complete, use RegularGridInterpolator
-            values = zks.reshape(y_grid.size, x_grid.size, -1)
-            interpolator = RegularGridInterpolator((y_grid, x_grid), values)
-        else:
-            # Otherwise, use LinearNDInterpolator
-            interpolator = LinearNDInterpolator(np.column_stack([y, x]), zks)
+        # Create interpolator
+        interpolator = LinearNDInterpolator(np.column_stack([y, x]), zks)
 
         return interpolator
 

--- a/tests/task/test_calcZernikesDanishTaskCwfs.py
+++ b/tests/task/test_calcZernikesDanishTaskCwfs.py
@@ -337,26 +337,30 @@ class TestCalcZernikesDanishTaskCwfs(lsst.utils.tests.TestCase):
 
     def testCreateIntrinsicMap(self) -> None:
         for intrinsicTable in self.intrinsicTables:
-            # Create intrinsic maps with complete grid
-            intrinsicMap = self.task._createIntrinsicMap(intrinsicTable)
-            self.assertEqual(
-                intrinsicMap(
-                    [intrinsicTable["y"].to("deg").value[0], intrinsicTable["x"].to("deg").value[0]]
-                )[0][0],
-                intrinsicTable["Z4"].to("um").value[0],
-            )
-            self.assertIsInstance(intrinsicMap, RegularGridInterpolator)
-            # Create intrinsic maps with "vignetted" grid (remove some points)
-            intrinsicTableVignetted = intrinsicTable[10:]
-            intrinsicMapVignetted = self.task._createIntrinsicMap(intrinsicTableVignetted)
-            self.assertEqual(
-                intrinsicMapVignetted(
-                    intrinsicTableVignetted["y"].to("deg").value[0],
-                    intrinsicTableVignetted["x"].to("deg").value[0],
-                )[0],
-                intrinsicTableVignetted["Z4"].to("um").value[0],
-            )
-            self.assertIsInstance(intrinsicMapVignetted, LinearNDInterpolator)
+            # For tests below, we will sort tables in
+            # two different orders to make sure nothing
+            # depends on table ordering
+            for order in (["x", "y"], ["y", "x"]):
+                table = intrinsicTable.copy()
+                table.sort(order)
+
+                # Create intrinsic maps with complete grid
+                intrinsicMap = self.task._createIntrinsicMap(table)
+                self.assertEqual(
+                    intrinsicMap([table["y"].to("deg").value[2], table["x"].to("deg").value[2]])[0, 0],
+                    table["Z4"].to("um").value[2],
+                )
+
+                # Create intrinsic maps with "vignetted" grid (remove some points)
+                tableVignetted = table[10:]
+                intrinsicMapVignetted = self.task._createIntrinsicMap(tableVignetted)
+                self.assertEqual(
+                    intrinsicMapVignetted(
+                        tableVignetted["y"].to("deg").value[0],
+                        tableVignetted["x"].to("deg").value[0],
+                    )[0],
+                    tableVignetted["Z4"].to("um").value[0],
+                )
 
     def testFitFailureWithMaxIterations(self) -> None:
         # Set max iterations very low to force fit failures


### PR DESCRIPTION
Note I changed the unit test to test this explicitly by re-ordering the tables in two different ways and checking for equality. I also changed the test point from the tables so that it is sensitive to these kinds of errors. I then confirmed the old code failed the new version of the test before fixing.