### PR TITLE
Intrinsic interpolators now directly use CCS

### DIFF
--- a/python/lsst/ts/wep/task/calcZernikesTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesTask.py
@@ -203,8 +203,9 @@ class CalcZernikesTask(pipeBase.PipelineTask, metaclass=abc.ABCMeta):
         Returns
         -------
         interpolator : scipy.interpolate.RegularGridInterpolator or None
-            Interpolator for the intrinsic Zernike map,
-            or None if no table is provided.
+            Interpolator for the intrinsic Zernike map, or None if no
+            table is provided. Note the interpolator expects points
+            in degrees, in CCS, and return intrinsics in microns.
         """
         if intrinsicTable is None:
             return None
@@ -218,7 +219,7 @@ class CalcZernikesTask(pipeBase.PipelineTask, metaclass=abc.ABCMeta):
         zks = np.column_stack([zkTable[col].to("um").value for col in zkTable.colnames])
 
         # Create interpolator
-        interpolator = LinearNDInterpolator(np.column_stack([y, x]), zks)
+        interpolator = LinearNDInterpolator(np.column_stack([x, y]), zks)
 
         return interpolator
 
@@ -257,12 +258,9 @@ class CalcZernikesTask(pipeBase.PipelineTask, metaclass=abc.ABCMeta):
             else:
                 intrinsicMap = self.intrinsicMapIntra
 
-            # Note that if you compare to the _createIntrinsicMap method you
-            # might think we would need to reverse the fieldAngle here (i.e.
-            # swap x and y), however stamp.calcFieldXY() returns coordinates
-            # in the DVCS instead of CCS, which is equivalent to already
-            # swapping x and y. Therefore we will not reverse the order here.
-            intrinsics = intrinsicMap(fieldAngle.value.tolist()) * u.micron  # type: ignore
+            # The interpolator expects points in CCS, but fieldAngle above
+            # is in DVCS, so we need to swap x and y (transpose)
+            intrinsics = intrinsicMap(fieldAngle.value[::-1].tolist()) * u.micron
 
         return fieldAngle, centroid, intrinsics
 

--- a/python/lsst/ts/wep/task/calcZernikesTask.py
+++ b/python/lsst/ts/wep/task/calcZernikesTask.py
@@ -260,7 +260,8 @@ class CalcZernikesTask(pipeBase.PipelineTask, metaclass=abc.ABCMeta):
 
             # The interpolator expects points in CCS, but fieldAngle above
             # is in DVCS, so we need to swap x and y (transpose)
-            intrinsics = intrinsicMap(fieldAngle.value[::-1].tolist()) * u.micron
+            fieldAngleCCS = fieldAngle.value[::-1]
+            intrinsics = intrinsicMap(fieldAngleCCS.tolist()) * u.micron  # type: ignore
 
         return fieldAngle, centroid, intrinsics
 

--- a/tests/task/test_calcZernikesDanishTaskCwfs.py
+++ b/tests/task/test_calcZernikesDanishTaskCwfs.py
@@ -346,20 +346,21 @@ class TestCalcZernikesDanishTaskCwfs(lsst.utils.tests.TestCase):
 
                 # Create intrinsic maps with complete grid
                 intrinsicMap = self.task._createIntrinsicMap(table)
+                interpolated = intrinsicMap([table["x"].to("deg").value[2], table["y"].to("deg").value[2]])
                 self.assertEqual(
-                    intrinsicMap([table["y"].to("deg").value[2], table["x"].to("deg").value[2]])[0, 0],
+                    interpolated[0, 0],
                     table["Z4"].to("um").value[2],
                 )
 
                 # Create intrinsic maps with "vignetted" grid (remove some points)
                 tableVignetted = table[10:]
                 intrinsicMapVignetted = self.task._createIntrinsicMap(tableVignetted)
+                interpolated = intrinsicMapVignetted(
+                    [tableVignetted["x"].to("deg").value[2], tableVignetted["y"].to("deg").value[2]]
+                )
                 self.assertEqual(
-                    intrinsicMapVignetted(
-                        tableVignetted["y"].to("deg").value[0],
-                        tableVignetted["x"].to("deg").value[0],
-                    )[0],
-                    tableVignetted["Z4"].to("um").value[0],
+                    interpolated[0, 0],
+                    tableVignetted["Z4"].to("um").value[2],
                 )
 
     def testFitFailureWithMaxIterations(self) -> None:


### PR DESCRIPTION
When removing the old `RegularGridInterpolator`, I missed the opportunity to simplify the code by making the interpolators more straightforwardly accepts coordinates in CCS. This small fix makes this change.

I also improved the documentation for the interpolator to note it takes field angles in CCS, in degrees.