### PR TITLE
Tickets/DM-54890: fix DonutCorrelator

### DIFF
--- a/doc/news/DM-54890.bugfix.md
+++ b/doc/news/DM-54890.bugfix.md
@@ -1,0 +1,1 @@
+Guard donutCorrelator when entire image is masked.

--- a/python/lsst/ts/wep/donutSizeCorrelator.py
+++ b/python/lsst/ts/wep/donutSizeCorrelator.py
@@ -78,7 +78,13 @@ class DonutSizeCorrelator:
         image[mask] = fillVal
 
         # Normalize the image
-        image /= image[~mask].max()
+        if np.any(~mask):
+            image /= image[~mask].max()
+        else:
+            # Entire image is masked — return zeros
+            image[:] = 0.0
+        return image
+
         return image
 
     @staticmethod

--- a/python/lsst/ts/wep/donutSizeCorrelator.py
+++ b/python/lsst/ts/wep/donutSizeCorrelator.py
@@ -85,8 +85,6 @@ class DonutSizeCorrelator:
             image[:] = 0.0
         return image
 
-        return image
-
     @staticmethod
     def cropAndBinImage(
         image: np.ndarray,

--- a/tests/test_donutSizeCorrelator.py
+++ b/tests/test_donutSizeCorrelator.py
@@ -154,6 +154,24 @@ class TestDonutSizeCorrelator(lsst.utils.tests.TestCase):
         self.assertGreater(diameter, 200)
         self.assertTrue(abs(diameter - instrument.donutDiameter) < 25)  # Loose tolerance
 
+    def testPrepButlerExposureFullyMasked(self) -> None:
+        """Test that prepButlerExposure returns zeros when the entire
+        image is masked, instead of crashing on empty array max()."""
+        exposure = self.butler.get(
+            "post_isr_image",
+            dataId=self.dataId,
+            collections=[self.runName],
+        )
+
+        # Set every pixel to SAT so the entire mask is bad
+        exposure.mask.array[:] = exposure.mask.getPlaneBitMask("SAT")
+
+        image = self.correlator.prepButlerExposure(exposure)
+
+        self.assertIsInstance(image, np.ndarray)
+        self.assertTrue(np.all(np.isfinite(image)))  # No NaNs or infs
+        self.assertTrue(np.all(image == 0.0))  # All zeros
+
     @classmethod
     def tearDownClass(cls) -> None:
         cleanUpCmd = writeCleanUpRepoCmd(cls.repoDir, cls.runName)


### PR DESCRIPTION
Guard correlator against  a situation when the entire image is masked.  